### PR TITLE
Add support for Netlify to contact form

### DIFF
--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -22,8 +22,11 @@ custom_script = ""
 
 mainSections = ["blog"]
 
+# contact form works with https://formspree.io and Netlify
+# use Netlify's contact form functionality
+netlify = true # set to false if using formspree.io
 # contact form action
-contact_form_action = "#" # contact form works with https://formspree.io
+contact_form_action = "#"
 # copyright
 theme_copyright = true
 copyright = "Copyright by your company"

--- a/exampleSite/content/english/contact.md
+++ b/exampleSite/content/english/contact.md
@@ -3,10 +3,13 @@ title: "Contact"
 description: "this is meta description"
 layout: "contact"
 draft: false
+form_name: "contact"
 ---
 
 # Contact Me
 
-Menso comes with a built-in contact form, that you can use with Formspree service to
-handle up to 50 submissions per month for free. You could also easily switch to another
-contact form service if you want
+iWriter comes with a built-in contact form that you can use with Netlify or the Formspree.
+[Netlify](https://docs.netlify.com/forms/usage-and-billing/#app) allows for 100 submissions per month for free.
+[Formspree](https://formspree.io/plans) provides up to 50 submissions per month for free.
+You can also easily switch to another contact form service if you want.
+

--- a/layouts/_default/contact.html
+++ b/layouts/_default/contact.html
@@ -8,8 +8,7 @@
         <div class="pb-5">
           {{ .Content }}
         </div>
-        
-        <form action="{{ site.Params.contact_form_action }}" method="post">
+        <form action="{{ site.Params.contact_form_action }}" method="post" {{ with .Params.form_name }}name="{{ . }}"{{ end }} {{ if site.Params.netlify }}data-netlify="true" netlify-honeypot="always-empty"{{ end }}>
           <div class="row g-4">
             <div class="col-md-6 mb-3 mt-0">
               <input type="text" class="form-control" placeholder="{{ i18n `first_name`}}" aria-label="{{ i18n `first_name`}}" name="{{ i18n `first_name`}}" required>
@@ -23,6 +22,9 @@
          
             <div class="col-12 mb-3 mt-0">
               <textarea  rows="7" class="form-control mb-4" placeholder="{{ i18n `message`}}" id="floatingTextarea" name="{{ i18n `message`}}" required></textarea>
+            </div>
+            <div hidden="true">
+              <input type="text" class="form-control" placeholder="Don’t fill this out if you’re human:" name="always-empty">
             </div>
             <div class="col-12 mb-3 mt-0">
               <button type="submit" class="btn btn-primary btn-md">{{ i18n `submit`}}</button>
@@ -39,3 +41,4 @@
 <!--===================== Contact End =====================--> 
 
 {{ end }}
+


### PR DESCRIPTION
This adds support for using Netlify's form service and enables it by default. It also takes advantage of their spam protection. Lastly, it facilitates setting a name for your contact form in case you have more than one as the form name is utilized by Netlify.

The Netlify parts of this are based on their docs at:

- https://docs.netlify.com/forms/setup/
- https://docs.netlify.com/forms/spam-filters/

Please note that I updated the verbiage on the English example site, but not the French one. This is simply because I don't speak French.