### PR TITLE
Add Mastodon ownership verification and example social icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 - GDPR consent enabled
 - Open graph meta tag
 - Twitter card meta tag
+- Mastodon site verification
 
 ## Local development
 

--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -68,9 +68,10 @@ username = ""  # your username
 
 # site verifications
 [site_verification]
-google = "" # Your verification code
-bing = ""   # Your verification code
-baidu = ""  # Your verification code
+google = ""   # Your verification code
+bing = ""     # Your verification code
+baidu = ""    # Your verification code
+mastodon = "" # The URL to your profile a la https://example.com/@username
 
 
 # cookies
@@ -93,6 +94,11 @@ link = "#"
 [[social]]
 title = "twitter"
 icon = "fab fa-twitter" # fontawesome icon pack : https://fontawesome.com/icons/
+link = "#"
+
+[[social]]
+title = "mastodon"
+icon = "fab fa-mastodon" # fontawesome icon pack : https://fontawesome.com/icons/
 link = "#"
 
 [[social]]

--- a/layouts/partials/datasets/site-verifications.html
+++ b/layouts/partials/datasets/site-verifications.html
@@ -1,14 +1,18 @@
-<!-- google site verification -->
 {{ with site.Params.site_verification.google }}
+<!-- google site verification -->
 <meta name="google-site-verification" content="{{ . }}" />
 {{ end }}
 
-<!-- bing site verification -->
 {{ with site.Params.site_verification.baidu }}
+<!-- bing site verification -->
 <meta name="msvalidate.01" content="{{ . }}" />
 {{ end }}
 
-<!-- baidu site verification -->
 {{ with site.Params.site_verification.baidu }}
+<!-- baidu site verification -->
 <meta name="baidu-site-verification" content="{{ . }}" />
 {{ end }}
+
+{{ with site.Params.site_verification.mastodon }}
+<!-- Mastodon site verification -->
+<link rel="me" href="{{ . }}" type="text/html">{{ end }}


### PR DESCRIPTION
When utilized, this will produce the rel=me link that Mastodon looks for when verifying a user owns a link listed in their profile.

The site verification partial is also updated so that comments are only rendered for sections that are actually used.

A social icon for Mastodon is also added into the example site's config