### PR TITLE
Don't cache twitter stuff - it changes on each page

### DIFF
--- a/layouts/partials/essentials/head.html
+++ b/layouts/partials/essentials/head.html
@@ -41,7 +41,7 @@
 {{ partialCached "datasets/site-verifications.html" . }}
 
 <!-- twitter card -->
-{{ partialCached "datasets/twitter-card.html" . }}
+{{ partial "datasets/twitter-card.html" . }}
 
 <!-- opengraph -->
 {{ template "_internal/opengraph.html" . }}


### PR DESCRIPTION
Prior to this change the description and title and image frequently were from some page other than the one being looked at. This was especially prevalent on the home page. During my testing, I also observed that caching this partial resulted in Hugo's `.IsHome` function returning false on the home page.

Fixes #9 